### PR TITLE
Meta Object / Dynamic List / Map support

### DIFF
--- a/Baku.LibqiDotNet/Baku.LibqiDotNet/Core/QiMethod/QiMethods.cs
+++ b/Baku.LibqiDotNet/Baku.LibqiDotNet/Core/QiMethod/QiMethods.cs
@@ -2,8 +2,6 @@
 using System.Collections.Generic;
 using System.Linq;
 
-using Baku.LibqiDotNet.Utils;
-
 namespace Baku.LibqiDotNet
 {
     /// <summary>Qi Frameworkのモジュールに定義された関数の一覧を表します。</summary>

--- a/Baku.LibqiDotNet/Baku.LibqiDotNet/Core/QiObject.cs
+++ b/Baku.LibqiDotNet/Baku.LibqiDotNet/Core/QiObject.cs
@@ -23,8 +23,14 @@ namespace Baku.LibqiDotNet
         public void Destroy() => QiApiObject.Destroy(this);
 
         private QiValue _metaObject;
-        /// <summary>サービスの内部情報を表すメタオブジェクトを取得します。</summary>
         internal QiValue MetaObject => _metaObject ?? (_metaObject = QiApiObject.GetMetaObject(this));
+
+        /// <summary>サービスの内部情報を表すメタオブジェクトを取得します。</summary>
+        /// <returns>
+        /// サービスの内部情報を表すメタオブジェクト。
+        /// とりあえず内容一覧を見たい場合などは<see cref="QiValue.Dump(int, int)"/>を用いる
+        /// </returns>
+        public QiValue GetMetaObject() => QiApiObject.GetMetaObject(this);
 
         private string _description = null;
         /// <summary>サービスの機能に関する説明文を取得します。</summary>

--- a/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiList.cs
+++ b/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiList.cs
@@ -171,12 +171,22 @@ namespace Baku.LibqiDotNet
         /// <summary>
         /// IEnumerableを対応する<see cref="QiList"/>に変換します。
         /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="values"></param>
-        /// <returns></returns>
-        public static QiList<T> ToQiList<T>(this IEnumerable<T> values) 
+        /// <typeparam name="T">要素の型</typeparam>
+        /// <param name="values">実際の要素の列挙</param>
+        /// <returns>指定したデータを保持する配列</returns>
+        public static QiList<T> ToQiList<T>(this IEnumerable<T> values)
             where T : QiAnyValue
             => QiList<T>.Create(values);
+
+        /// <summary>
+        /// 動的型(<see cref="QiDynamic"/>)でパックした配列への変換を行います。
+        /// </summary>
+        /// <param name="values">何かしらの値の列挙</param>
+        /// <returns>指定した値を保持する動的型のリスト</returns>
+        public static QiList<QiDynamic> ToQiDynamicList<T>(this IEnumerable<T> values)
+            where T : QiAnyValue
+            => QiList.CreateDynamic(values.Cast<QiAnyValue>());
+
 
     }
 

--- a/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiList.cs
+++ b/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiList.cs
@@ -4,26 +4,18 @@ using System.Linq;
 
 namespace Baku.LibqiDotNet
 {
-    /// <summary>一般的な配列型を表します。</summary>
-    public abstract class QiListBase : QiAnyValue
-    {
-        /// <summary>要素数を取得します。</summary>
-        public int Count => QiValue.Count;
-
-        /// <summary>インデクスを指定して要素を取得、設定します。</summary>
-        /// <param name="i">インデックス</param>
-        /// <returns>インデックスで指定した要素</returns>
-        public abstract QiValue this[int i] { get; set; }
-    }
-
     /// <summary>可変な配列型を表します。配列は単調に伸びる処理だけが許可されています。</summary>
-    public sealed class QiList<T> : QiListBase where T : QiAnyValue
+    public sealed class QiList<T> : QiAnyValue 
+        where T : QiAnyValue
     {
         private QiList(QiValue value, string sig)
         {
             QiValue = value;
             Signature = sig;
         }
+
+        /// <summary>要素数を取得します。</summary>
+        public int Count => QiValue.Count;
 
         /// <summary>ラップしている<see cref="QiValue"/>型の値を取得します。</summary>
         public override QiValue QiValue { get; }
@@ -34,7 +26,7 @@ namespace Baku.LibqiDotNet
         /// <summary>インデクスを指定して要素を取得、設定します。</summary>
         /// <param name="i">インデックス</param>
         /// <returns>インデックスで指定した要素</returns>
-        public override QiValue this[int i]
+        public QiValue this[int i]
         {
             get { return this.QiValue[i]; }
             set { this.QiValue[i] = value; }
@@ -80,41 +72,9 @@ namespace Baku.LibqiDotNet
         /// </summary>
         /// <param name="values">何かしらの値の列挙</param>
         /// <returns></returns>
-        public static QiList<T> Create<T>(IEnumerable<T> values) where T : QiAnyValue
+        public static QiList<T> Create<T>(IEnumerable<T> values) 
+            where T : QiAnyValue
             => QiList<T>.Create(values);
-
-        /// <summary>
-        /// <see cref="QiAnyValue"/>の派生型ではない型(基本的に組み込み型を想定)の型変換をしつつ配列を取得します。
-        /// </summary>
-        /// <typeparam name="T">一般的な組み込み型、または組み込み型の列挙<see cref="IEnumerable{T}"/></typeparam>
-        /// <param name="values">格納する値の一覧</param>
-        /// <returns>指定した値と等価な内容を含むQi Frameworkの配列</returns>
-        public static QiListBase CreateFrom<T>(IEnumerable<T> values)
-        {
-            var type = typeof(T);
-            switch (Type.GetTypeCode(type))
-            {
-                case TypeCode.Boolean: return Create(values.Select(v=> new QiBool((bool)Convert.ChangeType(v, TypeCode.Boolean))));
-                case TypeCode.Byte: return Create(values.Select(v => new QiUInt8((byte)Convert.ChangeType(v, TypeCode.Byte))));
-                case TypeCode.UInt16: return Create(values.Select(v => new QiUInt16((ushort)Convert.ChangeType(v, TypeCode.UInt16))));
-                case TypeCode.UInt32: return Create(values.Select(v => new QiUInt32((uint)Convert.ChangeType(v, TypeCode.UInt32))));
-                case TypeCode.UInt64: return Create(values.Select(v => new QiUInt64((ulong)Convert.ChangeType(v, TypeCode.UInt64))));
-                case TypeCode.SByte: return Create(values.Select(v => new QiInt8((sbyte)Convert.ChangeType(v, TypeCode.SByte))));
-                case TypeCode.Int16: return Create(values.Select(v => new QiInt16((short)Convert.ChangeType(v, TypeCode.Int16))));
-                case TypeCode.Int32: return Create(values.Select(v => new QiInt32((int)Convert.ChangeType(v, TypeCode.Int32))));
-                case TypeCode.Int64: return Create(values.Select(v => new QiInt64((long)Convert.ChangeType(v, TypeCode.Int64))));
-                case TypeCode.String: return Create(values.Select(v => new QiString((string)Convert.ChangeType(v, TypeCode.String))));
-                case TypeCode.Single: return Create(values.Select(v => new QiFloat((float)Convert.ChangeType(v, TypeCode.Single))));
-                case TypeCode.Double: return Create(values.Select(v => new QiDouble((double)Convert.ChangeType(v, TypeCode.Double))));
-                default: break;
-            }
-
-            //バイトデータの配列ってAPIで見かけてない気がするのでサポートしない方針を取る
-            //if (type == typeof(byte[])) return new QiByteData(v as byte[]);
-
-
-            throw new InvalidOperationException($"Given type is not supported, {type}");
-        }
 
         #region ひじょーにモッサリしてるが組み込み型からの配列生成をサポートしとく
 
@@ -174,7 +134,6 @@ namespace Baku.LibqiDotNet
         #endregion
     }
 
-
     /// <summary><see cref="QiList"/>を扱いやすくするための拡張メソッドを定義します。</summary>
     public static class QiListExtension
     {
@@ -184,7 +143,8 @@ namespace Baku.LibqiDotNet
         /// <typeparam name="T"></typeparam>
         /// <param name="values"></param>
         /// <returns></returns>
-        public static QiList<T> ToQiList<T>(this IEnumerable<T> values) where T : QiAnyValue
+        public static QiList<T> ToQiList<T>(this IEnumerable<T> values) 
+            where T : QiAnyValue
             => QiList<T>.Create(values);
 
     }

--- a/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiList.cs
+++ b/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiList.cs
@@ -62,6 +62,29 @@ namespace Baku.LibqiDotNet
             return new QiList<T>(list, sig);
         }
 
+        /// <summary>
+        /// 列挙された<see cref="QiAnyValue"/>派生型を要素として含む、動的型の内容からなるリストを生成します。
+        /// </summary>
+        /// <param name="values">何かしらの値の列挙</param>
+        /// <returns>指定した値を保持する動的型のリスト</returns>
+        public static QiList<QiDynamic> CreateDynamic(IEnumerable<QiAnyValue> values)
+        {
+            if (!values.Any())
+            {
+                throw new InvalidOperationException("values length must be greater than 0");
+            }
+
+            string sig = QiSignatures.TypeListBegin + QiSignatures.TypeDynamic + QiSignatures.TypeListEnd;
+
+            var list = QiValue.Create(sig);
+            foreach (var v in values)
+            {
+                list.AddElement(v.QiValue);
+            }
+
+            return new QiList<QiDynamic>(list, sig);
+        }
+
     }
 
     /// <summary><see cref="QiList{T}"/>のファクトリメソッドを定義します。</summary>
@@ -75,6 +98,14 @@ namespace Baku.LibqiDotNet
         public static QiList<T> Create<T>(IEnumerable<T> values) 
             where T : QiAnyValue
             => QiList<T>.Create(values);
+
+        /// <summary>
+        /// 列挙された<see cref="QiAnyValue"/>派生型を要素として含む、動的型の内容からなるリストを生成します。
+        /// </summary>
+        /// <param name="values">何かしらの値の列挙</param>
+        /// <returns>指定した値を保持する動的型のリスト</returns>
+        public static QiList<QiDynamic> CreateDynamic(IEnumerable<QiAnyValue> values)
+            => QiList<QiAnyValue>.CreateDynamic(values);
 
         #region ひじょーにモッサリしてるが組み込み型からの配列生成をサポートしとく
 

--- a/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiTuple.cs
+++ b/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiTuple.cs
@@ -56,7 +56,7 @@ namespace Baku.LibqiDotNet
         public static QiTuple CreateDynamic(params QiAnyValue[] values)
         {
             string sig = QiSignatures.TypeTupleBegin +
-                string.Join("", values.Select(_ => QiSignatures.TypeDynamic).ToArray()) +
+                new string(QiSignatures.TypeDynamic[0], values.Length) +
                 QiSignatures.TypeTupleEnd;
 
             var tuple = QiValue.Create(sig);

--- a/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiTuple.cs
+++ b/Baku.LibqiDotNet/Baku.LibqiDotNet/ValueTypes/QiTuple.cs
@@ -27,7 +27,7 @@ namespace Baku.LibqiDotNet
         {
             string sig = 
                 QiSignatures.TypeTupleBegin +
-                string.Join("", values.Select(_ => QiSignatures.TypeDynamic).ToArray()) + 
+                string.Join("", values.Select(v => v.Signature).ToArray()) + 
                 QiSignatures.TypeTupleEnd;
 
             var tuple = QiValue.Create(sig);


### PR DESCRIPTION
タイトルの通り下記を追加しつつ若干のリファクタリング
- メタオブジェクトの取得(`QiObject.GetMetaObject`)
- 動的型リストを作る静的メソッドと拡張メソッド(`QiList.CreateDynamic`と`IE<T>.ToQiDynamicList`)
- 辞書型のデータを扱いやすいよう`QiValue`に`MapKeys`と`MapValues`と`MapItems`プロパティ
